### PR TITLE
fix contact links not showing title correctly

### DIFF
--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -147,6 +147,14 @@ const printInfo = [email, phone, linkedUrl].filter(Boolean).join(" • ")
     width: 32px;
     border-radius: 6px;
     transition: all 0.3s ease;
+    position: relative;
+  }
+
+  footer a::after {
+    content: "";
+    width: 100%;
+    height: 100%;
+    position: absolute;
   }
 
   footer a:hover {


### PR DESCRIPTION
##before
when a contact link is hovered it shows the icon title and not the expected link title 
![image](https://github.com/edwarhman/cv-json/assets/69490591/fe8751ae-7a14-4d79-8619-0c3efe4b1ff7)


![image](https://github.com/edwarhman/cv-json/assets/69490591/7a5da9aa-c39b-4320-a88a-8fdbeb454966)
